### PR TITLE
Fixed build warnings originating from upstream code

### DIFF
--- a/Real-Time Corruptor/BizHawk_RTC/BizHawk.Client.ApiHawk/BizHawk.Client.ApiHawk.csproj
+++ b/Real-Time Corruptor/BizHawk_RTC/BizHawk.Client.ApiHawk/BizHawk.Client.ApiHawk.csproj
@@ -33,6 +33,8 @@
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NoWarn>0168</NoWarn> <!-- RTCV: Ignore warnings generated from upstream (Bizhawk) code -->
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3270</MSBuildWarningsAsMessages> <!-- RTCV: Ignore warnings generated from upstream (Bizhawk) code -->
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -127,7 +129,7 @@
     <None Include="Resources\ApiClassDiagram.cd" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Real-Time Corruptor/BizHawk_RTC/BizHawk.Client.Common/BizHawk.Client.Common.csproj
+++ b/Real-Time Corruptor/BizHawk_RTC/BizHawk.Client.Common/BizHawk.Client.Common.csproj
@@ -14,6 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
+    <NoWarn>0168,0414</NoWarn> <!-- RTCV: Ignore warnings generated from upstream (Bizhawk) code -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -335,7 +336,7 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Real-Time Corruptor/BizHawk_RTC/BizHawk.Client.EmuHawk/BizHawk.Client.EmuHawk.csproj
+++ b/Real-Time Corruptor/BizHawk_RTC/BizHawk.Client.EmuHawk/BizHawk.Client.EmuHawk.csproj
@@ -38,6 +38,8 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <NoWarn>0067,0162,0168,MSB3277</NoWarn> <!-- RTCV: Ignore warnings generated from upstream (Bizhawk) code -->
+    <MSBuildWarningsAsMessages>MSB3277</MSBuildWarningsAsMessages> <!-- RTCV: Ignore warnings generated from upstream (Bizhawk) code -->
   </PropertyGroup>
   <PropertyGroup>
     <NoWin32Manifest>true</NoWin32Manifest>
@@ -2296,7 +2298,7 @@
     <Folder Include="config\Saturn\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Real-Time Corruptor/BizHawk_RTC/BizHawk.Client.MultiHawk/BizHawk.Client.MultiHawk.csproj
+++ b/Real-Time Corruptor/BizHawk_RTC/BizHawk.Client.MultiHawk/BizHawk.Client.MultiHawk.csproj
@@ -36,6 +36,7 @@
     <TargetFrameworkProfile />
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <MSBuildWarningsAsMessages>MSB3277</MSBuildWarningsAsMessages> <!-- RTCV: Ignore warnings generated from upstream (Bizhawk) code -->
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualBasic" />
@@ -251,7 +252,7 @@
     <None Include="images\restart.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Real-Time Corruptor/BizHawk_RTC/BizHawk.Emulation.Cores/BizHawk.Emulation.Cores.csproj
+++ b/Real-Time Corruptor/BizHawk_RTC/BizHawk.Emulation.Cores/BizHawk.Emulation.Cores.csproj
@@ -32,6 +32,7 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
+    <NoWarn>0162,0169,0219,0414,0612,0649,0675</NoWarn> <!-- RTCV: Ignore warnings generated from upstream (Bizhawk) code -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -1730,7 +1731,7 @@
   <PropertyGroup>
     <PreBuildEvent />
   </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Real-Time Corruptor/BizHawk_RTC/BizHawk.Emulation.DiscSystem/BizHawk.Emulation.DiscSystem.csproj
+++ b/Real-Time Corruptor/BizHawk_RTC/BizHawk.Emulation.DiscSystem/BizHawk.Emulation.DiscSystem.csproj
@@ -38,6 +38,7 @@
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NoWarn>0649</NoWarn> <!-- RTCV: Ignore warnings generated from upstream (Bizhawk) code -->
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -128,7 +129,7 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Real-Time Corruptor/BizHawk_RTC/Bizware/BizHawk.Bizware.BizwareGL.SlimDX/BizHawk.Bizware.BizwareGL.SlimDX.csproj
+++ b/Real-Time Corruptor/BizHawk_RTC/Bizware/BizHawk.Bizware.BizwareGL.SlimDX/BizHawk.Bizware.BizwareGL.SlimDX.csproj
@@ -13,6 +13,8 @@
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NoWarn>0168</NoWarn> <!-- RTCV: Ignore warnings generated from upstream (Bizhawk) code -->
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3270</MSBuildWarningsAsMessages> <!-- RTCV: Ignore warnings generated from upstream (Bizhawk) code -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -74,7 +76,7 @@
     <Compile Include="IGL_SlimDX9.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
This is my effort to ignore the noisy warnings coming from Bizhawk code. I've labeled all of my workarounds with "RTCV". This should make it easier to handle merge conflicts if any show up when we pull from upstream.